### PR TITLE
fix for the leaderboard erroring

### DIFF
--- a/src/commands/current.ts
+++ b/src/commands/current.ts
@@ -6,7 +6,7 @@ import { TextChannel } from 'discord.js';
 
 module.exports = {
     name: "current",
-    aliases: ["count"],
+    aliases: ["count", "curr"],
     description: "get the current count",
     async execute(client: CommandClient, message: ExtMessage, args: string[]) {
         try {

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -21,7 +21,7 @@ module.exports = {
             for (let i = 0; i < guildsLb.length; i++) {
                 const g = guildsLb[i];
                 if (g.guildID) {
-                    const gu = client.guilds.cache.get(g.guildID) || await client.guilds.fetch(g.guildID);
+                    const gu = client.guilds.cache.get(g.guildID);
                     if (gu) {
                         if (longestNameLength < gu.name.length) longestNameLength = gu.name.length;
                     }
@@ -38,7 +38,7 @@ module.exports = {
             for (let i = 0; i < guildsLb.length; i++) {
                 const g = guildsLb[i];
                 if (g.guildID) {
-                    const gu = client.guilds.cache.get(g.guildID) || await client.guilds.fetch(g.guildID);
+                    const gu = client.guilds.cache.get(g.guildID);
                     if (gu) {
                         let guildName = gu.name;
                         if (guildName.length > 20) {


### PR DESCRIPTION
The lb was erroring out when the bot was removed from a guild.
This occurred because the .fetch() method rejects when it cannot access.

resolves #9 