### PR TITLE
full fail role feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# RUN with sudo docker-compose up --build -d
+# RUN with `sudo docker-compose up --build -d -t countingman`
 
 FROM node:14-alpine3.10
 

--- a/src/commands/failrole.ts
+++ b/src/commands/failrole.ts
@@ -1,0 +1,53 @@
+import xlg from '../xlogger';
+import { sendError } from "../utils/messages";
+import checkAccess from '../utils/checkaccess';
+import { CommandClient, ExtMessage } from '../typings';
+import { TextChannel } from 'discord.js';
+import { stringToRole } from "../utils/parsers";
+
+module.exports = {
+    name: "failrole",
+    aliases: ["fr"],
+    usage: "<role (any form) | 'none'>",
+    args: true,
+    description: "set the role to give someone when they reset the count",
+    async execute(client: CommandClient, message: ExtMessage, args: string[]) {
+        try {
+            // check for perms
+            if (!(await checkAccess(message))) return;
+            if (!message.guild) return;
+
+            if (args.join(" ") === "none") {
+                await client.database?.setFailRole(message.guild.id, "");// set the failrole to "" to mean "none" (resetting)
+                message.channel.send({
+                    embed: {
+                        color: process.env.NAVY_COLOR,
+                        description: `The Fail Role has been reset.`
+                    }
+                });
+                return;
+            }
+
+            const target = stringToRole(message.guild, args.join(" "));// getting role from args
+            if (!target || typeof target === "string") {
+                if (!(message.channel instanceof TextChannel)) return false;
+                sendError(message.channel, "A valid role is required", true);
+                return false;
+            }
+
+            await client.database?.setFailRole(message.guild.id, target.id);// set the id of the failrole for the guild in the db
+            message.channel.send({
+                embed: {
+                    color: process.env.NAVY_COLOR,
+                    description: `The Fail Role has been set to ${target}.\nPeople who miscount and reset the score will receive this role.`
+                }
+            });
+            return;
+        } catch (error) {
+            xlg.error(error);
+            if (!(message.channel instanceof TextChannel)) return;
+            sendError(message.channel);
+            return false;
+        }
+    }
+}

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -39,6 +39,7 @@ export interface guildObject {
     count?: number;
     increment?: number;
     countChannel?: string;
+    failRole?: string;
     lastUpdatedID?: string;
     chatAllowed?: boolean;
     leaderboardEligible?: 0 | 1;

--- a/src/utils/counthandler.ts
+++ b/src/utils/counthandler.ts
@@ -84,6 +84,16 @@ async function handleFoul(client: CommandClient, message: ExtMessage, reason: st
     await client.database?.setLastUpdater(message.guild?.id || "", "");// reset lastUpdater for a new count (anyone can send)
     await client.database?.updateCount(message.guild?.id || "", 0);// reset the count
     await client.database?.incrementErrorCount(message.guild?.id || "");
+    // fail role handling
+    const failroleid = await client.database?.getFailRole(message.guild?.id || "");
+    if (failroleid && failroleid.length > 0) {
+        const failrole = message.guild?.roles.cache.get(failroleid);
+        if (!failrole) {
+            await client.database?.setFailRole(message.guild?.id || "", "");
+        } else {
+            message.member?.roles.add(failrole).catch(xlg.error);
+        }
+    }
 
     const increment = await client.database?.getIncrement(message.guild?.id);
     if (!increment) return false;

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,10 +1,11 @@
 import { TextChannel } from "discord.js"
 
-export function sendError(channel: TextChannel): undefined {
+export function sendError(channel: TextChannel, message?: string, errorTitle = false): undefined {
     channel.send({
         embed: {
-            color: 16711680,
-            description: "Something went wrong. ¯\\_(ツ)_/¯"
+            color: parseInt(process.env.FAIL_COLOR || "16711680"),
+            title: (errorTitle) ? "Error" : undefined,
+            description: (message && message.length) ? message : "Something went wrong. ¯\\_(ツ)_/¯"
         }
     }).catch(console.error)
     return;


### PR DESCRIPTION
Adding the feature and accompanying command for the `fail role`. A role that can be set by guild admins that will be given to people who reset the count.